### PR TITLE
fix segfault(file->log is NULL), logger fault

### DIFF
--- a/ngx_markdown_filter_module.c
+++ b/ngx_markdown_filter_module.c
@@ -139,6 +139,7 @@ static char *ngx_conf_set_template(ngx_conf_t *cf, ngx_command_t *cmd, void *con
     ngx_file_t file;
     file.fd = fd;
     file.info = fi;
+    file.log = cf->log;
 
     ngx_int_t n = ngx_read_file(&file, template, fi.st_size, 0);
     template[fi.st_size] = '\0';


### PR DESCRIPTION
![изображение](https://github.com/dura0ok/ngx_markdown_filter_module/assets/28489754/b68c3b32-33a8-4ad5-8a64-f9448c72c83a)
without this line, it crashes with a segfault, because it tries to log, but file->log NULL